### PR TITLE
Shut down entities on the application thread when deleting them

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.hpp
@@ -94,6 +94,9 @@ public:
   // Detach any attached wait set condition variable, and return whether there is data in the queue.
   bool detach_condition_and_queue_is_empty();
 
+  // Shutdown this ClientData.
+  rmw_ret_t shutdown();
+
   // Check if this ClientData is shutdown.
   bool is_shutdown() const;
 
@@ -112,9 +115,6 @@ private:
     const void * response_type_support_impl,
     std::shared_ptr<RequestTypeSupport> request_type_support,
     std::shared_ptr<ResponseTypeSupport> response_type_support);
-
-  // Shutdown this ClientData.
-  rmw_ret_t shutdown();
 
   // Internal mutex.
   mutable std::mutex mutex_;

--- a/rmw_zenoh_cpp/src/detail/rmw_node_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_node_data.cpp
@@ -180,8 +180,25 @@ PublisherDataPtr NodeData::get_pub_data(const rmw_publisher_t * const publisher)
 ///=============================================================================
 void NodeData::delete_pub_data(const rmw_publisher_t * const publisher)
 {
-  std::lock_guard<std::mutex> lock_guard(mutex_);
-  pubs_.erase(publisher);
+  std::shared_ptr<PublisherData> data;
+  {
+    std::lock_guard<std::mutex> lock_guard(mutex_);
+    auto it = pubs_.find(publisher);
+    if (it == pubs_.end()) {
+      return;
+    }
+    data = it->second;
+    pubs_.erase(it);
+  }
+  // Shut down the entity on this (application) thread, outside mutex_.
+  // If an in-flight zenoh callback still holds the last reference, the
+  // destructor would otherwise run the blocking undeclare on that callback's
+  // own thread and deadlock waiting for the callback to finish.
+  if (data->shutdown() != RMW_RET_OK) {
+    RMW_ZENOH_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "Unable to shutdown publisher within rmw_zenoh while deleting it.");
+  }
 }
 
 ///=============================================================================
@@ -250,8 +267,25 @@ SubscriptionDataPtr NodeData::get_sub_data(const rmw_subscription_t * const subs
 ///=============================================================================
 void NodeData::delete_sub_data(const rmw_subscription_t * const subscription)
 {
-  std::lock_guard<std::mutex> lock_guard(mutex_);
-  subs_.erase(subscription);
+  std::shared_ptr<SubscriptionData> data;
+  {
+    std::lock_guard<std::mutex> lock_guard(mutex_);
+    auto it = subs_.find(subscription);
+    if (it == subs_.end()) {
+      return;
+    }
+    data = it->second;
+    subs_.erase(it);
+  }
+  // Shut down the entity on this (application) thread, outside mutex_.
+  // If an in-flight zenoh callback still holds the last reference, the
+  // destructor would otherwise run the blocking undeclare on that callback's
+  // own thread and deadlock waiting for the callback to finish.
+  if (data->shutdown() != RMW_RET_OK) {
+    RMW_ZENOH_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "Unable to shutdown subscription within rmw_zenoh while deleting it.");
+  }
 }
 
 ///=============================================================================
@@ -317,8 +351,25 @@ ServiceDataPtr NodeData::get_service_data(const rmw_service_t * const service)
 ///=============================================================================
 void NodeData::delete_service_data(const rmw_service_t * const service)
 {
-  std::lock_guard<std::mutex> lock_guard(mutex_);
-  services_.erase(service);
+  std::shared_ptr<ServiceData> data;
+  {
+    std::lock_guard<std::mutex> lock_guard(mutex_);
+    auto it = services_.find(service);
+    if (it == services_.end()) {
+      return;
+    }
+    data = it->second;
+    services_.erase(it);
+  }
+  // Shut down the entity on this (application) thread, outside mutex_.
+  // If an in-flight zenoh callback still holds the last reference, the
+  // destructor would otherwise run the blocking undeclare on that callback's
+  // own thread and deadlock waiting for the callback to finish.
+  if (data->shutdown() != RMW_RET_OK) {
+    RMW_ZENOH_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "Unable to shutdown service within rmw_zenoh while deleting it.");
+  }
 }
 
 
@@ -385,8 +436,25 @@ ClientDataPtr NodeData::get_client_data(const rmw_client_t * const client)
 ///=============================================================================
 void NodeData::delete_client_data(const rmw_client_t * const client)
 {
-  std::lock_guard<std::mutex> lock_guard(mutex_);
-  clients_.erase(client);
+  std::shared_ptr<ClientData> data;
+  {
+    std::lock_guard<std::mutex> lock_guard(mutex_);
+    auto it = clients_.find(client);
+    if (it == clients_.end()) {
+      return;
+    }
+    data = it->second;
+    clients_.erase(it);
+  }
+  // Shut down the entity on this (application) thread, outside mutex_.
+  // If an in-flight zenoh callback still holds the last reference, the
+  // destructor would otherwise run the blocking undeclare on that callback's
+  // own thread and deadlock waiting for the callback to finish.
+  if (data->shutdown() != RMW_RET_OK) {
+    RMW_ZENOH_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "Unable to shutdown client within rmw_zenoh while deleting it.");
+  }
 }
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -189,6 +189,12 @@ std::shared_ptr<ServiceData> ServiceData::make(
     return nullptr;
   }
 
+  // Mark the entity as fully initialized so that shutdown() undeclares the
+  // queryable and the liveliness token itself, on the calling thread, instead
+  // of leaving that to the member destructors (which may run on a zenoh
+  // callback thread).
+  service_data->initialized_ = true;
+
   return service_data;
 }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.hpp
@@ -87,6 +87,9 @@ public:
 
   bool detach_condition_and_queue_is_empty();
 
+  // Shutdown this ServiceData.
+  rmw_ret_t shutdown();
+
   // Check if this ServiceData is shutdown.
   bool is_shutdown() const;
 
@@ -105,9 +108,6 @@ private:
     const void * response_type_support_impl,
     std::unique_ptr<RequestTypeSupport> request_type_support,
     std::unique_ptr<ResponseTypeSupport> response_type_support);
-
-  // Shutdown this ServiceData.
-  rmw_ret_t shutdown();
 
   // Internal mutex.
   mutable std::mutex mutex_;

--- a/test_rmw_zenoh_cpp/CMakeLists.txt
+++ b/test_rmw_zenoh_cpp/CMakeLists.txt
@@ -17,6 +17,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_common REQUIRED)
   find_package(rclcpp REQUIRED)
   find_package(rmw_zenoh_cpp REQUIRED)
+  find_package(test_msgs REQUIRED)
   find_package(zenoh_cpp_vendor REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
@@ -29,6 +30,16 @@ if(BUILD_TESTING)
     rmw_zenoh_cpp::rmw_zenoh_cpp
     zenohcxx::zenohc
     ament_cmake_ros_core::ament_ros_defaults
+  )
+
+  ament_add_ros_isolated_gtest(test_client_destroy_during_reply
+    test/test_client_destroy_during_reply.cpp
+    TIMEOUT 120
+    ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp)
+  target_link_libraries(test_client_destroy_during_reply
+    rclcpp::rclcpp
+    rmw_zenoh_cpp::rmw_zenoh_cpp
+    ${test_msgs_TARGETS}
   )
 endif()
 

--- a/test_rmw_zenoh_cpp/CMakeLists.txt
+++ b/test_rmw_zenoh_cpp/CMakeLists.txt
@@ -20,6 +20,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_common REQUIRED)
   find_package(rclcpp REQUIRED)
   find_package(rmw_zenoh_cpp REQUIRED)
+  find_package(test_msgs REQUIRED)
   find_package(zenoh_cpp_vendor REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
@@ -31,6 +32,16 @@ if(BUILD_TESTING)
     rclcpp::rclcpp
     rmw_zenoh_cpp::rmw_zenoh_cpp
     zenohcxx::zenohc
+  )
+
+  ament_add_ros_isolated_gtest(test_client_destroy_during_reply
+    test/test_client_destroy_during_reply.cpp
+    TIMEOUT 120
+    ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp)
+  target_link_libraries(test_client_destroy_during_reply
+    rclcpp::rclcpp
+    rmw_zenoh_cpp::rmw_zenoh_cpp
+    ${test_msgs_TARGETS}
   )
 endif()
 

--- a/test_rmw_zenoh_cpp/CMakeLists.txt
+++ b/test_rmw_zenoh_cpp/CMakeLists.txt
@@ -40,6 +40,29 @@ if(BUILD_TESTING)
     rclcpp::rclcpp
     rmw_zenoh_cpp::rmw_zenoh_cpp
     ${test_msgs_TARGETS}
+    ament_cmake_ros_core::ament_ros_defaults
+  )
+
+  ament_add_ros_isolated_gtest(test_service_destroy_during_request
+    test/test_service_destroy_during_request.cpp
+    TIMEOUT 120
+    ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp)
+  target_link_libraries(test_service_destroy_during_request
+    rclcpp::rclcpp
+    rmw_zenoh_cpp::rmw_zenoh_cpp
+    ${test_msgs_TARGETS}
+    ament_cmake_ros_core::ament_ros_defaults
+  )
+
+  ament_add_ros_isolated_gtest(test_subscription_destroy_during_sample
+    test/test_subscription_destroy_during_sample.cpp
+    TIMEOUT 120
+    ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp)
+  target_link_libraries(test_subscription_destroy_during_sample
+    rclcpp::rclcpp
+    rmw_zenoh_cpp::rmw_zenoh_cpp
+    ${test_msgs_TARGETS}
+    ament_cmake_ros_core::ament_ros_defaults
   )
 endif()
 

--- a/test_rmw_zenoh_cpp/package.xml
+++ b/test_rmw_zenoh_cpp/package.xml
@@ -15,6 +15,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>rmw_zenoh_cpp</test_depend>
+  <test_depend>test_msgs</test_depend>
   <test_depend>zenoh_cpp_vendor</test_depend>
 
   <export>

--- a/test_rmw_zenoh_cpp/package.xml
+++ b/test_rmw_zenoh_cpp/package.xml
@@ -16,6 +16,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>rmw_zenoh_cpp</test_depend>
+  <test_depend>test_msgs</test_depend>
   <test_depend>zenoh_cpp_vendor</test_depend>
 
   <export>

--- a/test_rmw_zenoh_cpp/test/test_client_destroy_during_reply.cpp
+++ b/test_rmw_zenoh_cpp/test/test_client_destroy_during_reply.cpp
@@ -1,0 +1,157 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <thread>
+
+#include <rclcpp/rclcpp.hpp>
+#include <test_msgs/srv/basic_types.hpp>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+template<typename Pred>
+bool poll_until(Pred && pred, std::chrono::seconds timeout)
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (pred()) {
+      return true;
+    }
+    std::this_thread::sleep_for(10ms);
+  }
+  return pred();
+}
+}  // namespace
+
+class TestClientDestroyDuringReply : public ::testing::Test
+{
+public:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+// Regression test: destroying a client while its zenoh reply callback is
+// still executing must not deadlock.
+//
+// The reply callback captures a weak_ptr to ClientData and locks it for the
+// duration of the callback. If rmw_destroy_client races with an in-flight
+// reply, the callback's transient shared_ptr can become the last strong
+// reference, so ~ClientData() — and with it the blocking querier undeclare,
+// which drains in-flight callbacks — runs on the very thread executing that
+// callback, waiting for itself forever.
+//
+// The test makes the race deterministic: ClientData::add_new_reply()
+// synchronously invokes the new-response callback while the reply closure
+// still holds its strong reference, so blocking inside that callback pins
+// the "reply in flight" state while the main thread destroys the client.
+TEST_F(TestClientDestroyDuringReply, DestroyWhileReplyCallbackInFlight)
+{
+  // The service lives on its own node, spun by a dedicated executor thread.
+  // The client node is intentionally never added to an executor so that
+  // client destruction order is fully controlled by this test.
+  auto service_node = std::make_shared<rclcpp::Node>("destroy_during_reply_service_node");
+  auto client_node = std::make_shared<rclcpp::Node>("destroy_during_reply_client_node");
+
+  auto service = service_node->create_service<test_msgs::srv::BasicTypes>(
+    "client_destroy_during_reply",
+    [](const std::shared_ptr<test_msgs::srv::BasicTypes::Request>,
+    std::shared_ptr<test_msgs::srv::BasicTypes::Response> response) {
+      response->bool_value = true;
+    });
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(service_node);
+  std::thread spinner([&executor]() {executor.spin();});
+
+  auto client = client_node->create_client<test_msgs::srv::BasicTypes>(
+    "client_destroy_during_reply");
+  ASSERT_TRUE(poll_until([&]() {return client->service_is_ready();}, 10s));
+
+  std::promise<void> reply_in_flight;
+  std::promise<void> release_reply;
+  std::shared_future<void> release_future = release_reply.get_future().share();
+  std::atomic<bool> first_reply{true};
+
+  // Fires inside ClientData::add_new_reply(), on the thread executing the
+  // zenoh reply closure, while that closure still holds a strong reference
+  // to ClientData.
+  client->set_on_new_response_callback(
+    [&reply_in_flight, release_future, &first_reply](size_t) {
+      if (first_reply.exchange(false)) {
+        reply_in_flight.set_value();
+        release_future.wait_for(10s);
+      }
+    });
+
+  client->async_send_request(std::make_shared<test_msgs::srv::BasicTypes::Request>());
+
+  ASSERT_EQ(reply_in_flight.get_future().wait_for(10s), std::future_status::ready)
+    << "service reply never reached the client";
+
+  // Keep the reply callback blocked while the client is destroyed, then let
+  // it finish: pre-fix, the callback thread then drops the last ClientData
+  // reference and self-deadlocks in the querier undeclare.
+  std::thread releaser([&release_reply]() {
+      std::this_thread::sleep_for(500ms);
+      release_reply.set_value();
+    });
+
+  client.reset();
+  releaser.join();
+
+  // Probe: the thread that executed the reply callback (the service node's
+  // spinner, since replies are delivered inline from rmw_send_response in a
+  // same-process setup) must still be alive and able to serve a new call.
+  auto probe = client_node->create_client<test_msgs::srv::BasicTypes>(
+    "client_destroy_during_reply");
+  ASSERT_TRUE(poll_until([&]() {return probe->service_is_ready();}, 10s));
+
+  std::promise<void> probe_replied;
+  std::atomic<bool> probe_first{true};
+  probe->set_on_new_response_callback(
+    [&probe_replied, &probe_first](size_t) {
+      if (probe_first.exchange(false)) {
+        probe_replied.set_value();
+      }
+    });
+  probe->async_send_request(std::make_shared<test_msgs::srv::BasicTypes::Request>());
+
+  const bool alive =
+    probe_replied.get_future().wait_for(10s) == std::future_status::ready;
+  if (!alive) {
+    // The executor thread is deadlocked; it can never be joined. Detach so
+    // the failure is reported instead of hanging in the thread destructor.
+    spinner.detach();
+    FAIL() << "no reply after destroying a client during its reply callback: "
+      "the zenoh callback thread is deadlocked (~ClientData ran a "
+      "blocking undeclare on its own callback thread)";
+  }
+
+  executor.cancel();
+  spinner.join();
+}

--- a/test_rmw_zenoh_cpp/test/test_service_destroy_during_request.cpp
+++ b/test_rmw_zenoh_cpp/test/test_service_destroy_during_request.cpp
@@ -1,0 +1,147 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <thread>
+
+#include <rclcpp/rclcpp.hpp>
+#include <test_msgs/srv/basic_types.hpp>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+template<typename Pred>
+bool poll_until(Pred && pred, std::chrono::seconds timeout)
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (pred()) {
+      return true;
+    }
+    std::this_thread::sleep_for(10ms);
+  }
+  return pred();
+}
+}  // namespace
+
+class TestServiceDestroyDuringRequest : public ::testing::Test
+{
+public:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+// Regression test: destroying a service while its zenoh query callback is
+// still executing must not deadlock.
+//
+// The queryable callback captures a weak_ptr to ServiceData and locks it for
+// the duration of the callback. If rmw_destroy_service races with an in-flight
+// request, the callback's transient shared_ptr can become the last strong
+// reference, so ~ServiceData() — and with it the blocking queryable undeclare,
+// which drains in-flight callbacks — runs on the very thread executing that
+// callback, waiting for itself forever.
+//
+// rmw_destroy_service is expected to shut the entity down on the calling
+// thread instead. That only works if ServiceData::shutdown() actually
+// undeclares the queryable, which it skips unless the entity was marked
+// initialized.
+//
+// The test makes the race deterministic: ServiceData::add_new_query()
+// synchronously invokes the new-request callback while the query closure still
+// holds its strong reference, so blocking inside that callback pins the
+// "request in flight" state while the main thread destroys the service.
+TEST_F(TestServiceDestroyDuringRequest, DestroyWhileRequestCallbackInFlight)
+{
+  // Neither node is added to an executor: the request only has to reach the
+  // rmw layer, and service destruction order is fully controlled by this test.
+  auto service_node = std::make_shared<rclcpp::Node>("destroy_during_request_service_node");
+  auto client_node = std::make_shared<rclcpp::Node>("destroy_during_request_client_node");
+
+  auto service = service_node->create_service<test_msgs::srv::BasicTypes>(
+    "service_destroy_during_request",
+    [](const std::shared_ptr<test_msgs::srv::BasicTypes::Request>,
+    std::shared_ptr<test_msgs::srv::BasicTypes::Response> response) {
+      response->bool_value = true;
+    });
+
+  auto client = client_node->create_client<test_msgs::srv::BasicTypes>(
+    "service_destroy_during_request");
+  ASSERT_TRUE(poll_until([&]() {return client->service_is_ready();}, 10s));
+
+  std::promise<void> request_in_flight;
+  std::promise<void> release_request;
+  std::shared_future<void> release_future = release_request.get_future().share();
+  std::atomic<bool> first_request{true};
+
+  // Fires inside ServiceData::add_new_query(), on the thread executing the
+  // zenoh query closure, while that closure still holds a strong reference
+  // to ServiceData.
+  service->set_on_new_request_callback(
+    [&request_in_flight, release_future, &first_request](size_t) {
+      if (first_request.exchange(false)) {
+        request_in_flight.set_value();
+        release_future.wait_for(10s);
+      }
+    });
+
+  // In a same-process setup the query is delivered to the local queryable
+  // synchronously from rmw_send_request, so the sender thread is the zenoh
+  // callback thread for this test.
+  std::promise<void> sender_done;
+  std::thread sender(
+    [&client, &sender_done]() {
+      client->async_send_request(std::make_shared<test_msgs::srv::BasicTypes::Request>());
+      sender_done.set_value();
+    });
+
+  ASSERT_EQ(request_in_flight.get_future().wait_for(10s), std::future_status::ready)
+    << "request never reached the service";
+
+  // Keep the request callback blocked while the service is destroyed, then
+  // let it finish: pre-fix, the sender thread then drops the last ServiceData
+  // reference and self-deadlocks in the queryable undeclare.
+  std::thread releaser([&release_request]() {
+      std::this_thread::sleep_for(500ms);
+      release_request.set_value();
+    });
+
+  service.reset();
+  releaser.join();
+
+  // The thread that executed the request callback must be able to return.
+  const bool alive =
+    sender_done.get_future().wait_for(10s) == std::future_status::ready;
+  if (!alive) {
+    // The sender thread is deadlocked; it can never be joined. Detach so the
+    // failure is reported instead of hanging in the thread destructor.
+    sender.detach();
+    FAIL() << "sender thread never returned after destroying a service during "
+      "its request callback: the zenoh callback thread is deadlocked "
+      "(~ServiceData ran a blocking undeclare on its own callback thread)";
+  }
+  sender.join();
+}

--- a/test_rmw_zenoh_cpp/test/test_subscription_destroy_during_sample.cpp
+++ b/test_rmw_zenoh_cpp/test/test_subscription_destroy_during_sample.cpp
@@ -1,0 +1,166 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <thread>
+
+#include <rclcpp/rclcpp.hpp>
+#include <test_msgs/msg/empty.hpp>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+template<typename Pred>
+bool poll_until(Pred && pred, std::chrono::seconds timeout)
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (pred()) {
+      return true;
+    }
+    std::this_thread::sleep_for(10ms);
+  }
+  return pred();
+}
+}  // namespace
+
+class TestSubscriptionDestroyDuringSample : public ::testing::Test
+{
+public:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+// Regression test: destroying a subscription while zenoh sample callbacks are
+// in flight must not deadlock.
+//
+// The sample callback locks SubscriptionData::mutex_ in add_new_message().
+// SubscriptionData::shutdown() must therefore release mutex_ before it
+// undeclares the subscriber: the undeclare blocks until every in-flight sample
+// callback has returned, and a callback that is waiting for mutex_ never
+// returns while shutdown() holds it (AB-BA between the application thread and
+// the callback thread).
+//
+// The test makes the race deterministic. In a same-process setup a publication
+// is delivered to the local subscriber synchronously on the publishing thread,
+// so two publisher threads play the role of two zenoh callback threads:
+//   1. thread A publishes and is parked inside the new-message callback, which
+//      add_new_message() invokes while holding mutex_;
+//   2. the destroyer thread enters shutdown() and queues up on mutex_;
+//   3. thread B publishes and queues up on mutex_ in add_new_message();
+//   4. thread A is released. The destroyer takes mutex_ and undeclares the
+//      subscriber while thread B is still in flight.
+// Pre-fix, step 4 deadlocks: the undeclare waits for B, and B waits for the
+// mutex_ the destroyer is holding across the undeclare.
+TEST_F(TestSubscriptionDestroyDuringSample, DestroyWhileSampleCallbacksInFlight)
+{
+  // Nodes are intentionally never added to an executor so that subscription
+  // destruction order is fully controlled by this test.
+  auto pub_node = std::make_shared<rclcpp::Node>("destroy_during_sample_pub_node");
+  auto sub_node = std::make_shared<rclcpp::Node>("destroy_during_sample_sub_node");
+
+  // Two publishers: PublisherData::publish() serializes on its own mutex, so
+  // two concurrent publications need two publishers.
+  auto pub_a = pub_node->create_publisher<test_msgs::msg::Empty>(
+    "subscription_destroy_during_sample", 10);
+  auto pub_b = pub_node->create_publisher<test_msgs::msg::Empty>(
+    "subscription_destroy_during_sample", 10);
+
+  auto sub = sub_node->create_subscription<test_msgs::msg::Empty>(
+    "subscription_destroy_during_sample", 10,
+    [](test_msgs::msg::Empty::ConstSharedPtr) {});
+  ASSERT_TRUE(poll_until([&]() {return pub_a->get_subscription_count() >= 1;}, 10s));
+  ASSERT_TRUE(poll_until([&]() {return pub_b->get_subscription_count() >= 1;}, 10s));
+
+  std::promise<void> sample_in_flight;
+  std::promise<void> release_sample;
+  std::shared_future<void> release_future = release_sample.get_future().share();
+  std::atomic<bool> first_sample{true};
+
+  // Fires inside SubscriptionData::add_new_message(), on the thread executing
+  // the zenoh sample closure, with SubscriptionData::mutex_ held and the
+  // closure still holding a strong reference to SubscriptionData.
+  sub->set_on_new_message_callback(
+    [&sample_in_flight, release_future, &first_sample](size_t) {
+      if (first_sample.exchange(false)) {
+        sample_in_flight.set_value();
+        release_future.wait_for(10s);
+      }
+    });
+
+  // Step 1: park thread A inside the callback.
+  std::promise<void> publisher_a_done;
+  std::thread publisher_a(
+    [&pub_a, &publisher_a_done]() {
+      pub_a->publish(test_msgs::msg::Empty());
+      publisher_a_done.set_value();
+    });
+  ASSERT_EQ(sample_in_flight.get_future().wait_for(10s), std::future_status::ready)
+    << "sample never reached the subscription";
+
+  // Step 2: destroy the subscription. shutdown() blocks on mutex_ behind A.
+  std::promise<void> destroy_done;
+  std::thread destroyer(
+    [&sub, &destroy_done]() {
+      sub.reset();
+      destroy_done.set_value();
+    });
+  std::this_thread::sleep_for(200ms);
+
+  // Step 3: a second in-flight sample, blocked on mutex_ in add_new_message().
+  std::promise<void> publisher_b_done;
+  std::thread publisher_b(
+    [&pub_b, &publisher_b_done]() {
+      pub_b->publish(test_msgs::msg::Empty());
+      publisher_b_done.set_value();
+    });
+  std::this_thread::sleep_for(200ms);
+
+  // Step 4: let A go. The destroyer now undeclares while B is in flight.
+  release_sample.set_value();
+
+  const bool destroyed =
+    destroy_done.get_future().wait_for(10s) == std::future_status::ready;
+  const bool b_returned =
+    publisher_b_done.get_future().wait_for(10s) == std::future_status::ready;
+  const bool a_returned =
+    publisher_a_done.get_future().wait_for(10s) == std::future_status::ready;
+  if (!destroyed || !b_returned || !a_returned) {
+    // Deadlocked threads can never be joined. Detach so the failure is
+    // reported instead of hanging in the thread destructors.
+    destroyer.detach();
+    publisher_b.detach();
+    publisher_a.detach();
+    FAIL() << "deadlock destroying a subscription with sample callbacks in flight "
+      "(destroy returned: " << destroyed << ", publisher A returned: " << a_returned <<
+      ", publisher B returned: " << b_returned << "): SubscriptionData::shutdown() "
+      "undeclared the subscriber while holding mutex_";
+  }
+  destroyer.join();
+  publisher_b.join();
+  publisher_a.join();
+}


### PR DESCRIPTION
## Description

Fixes #993.

`NodeData::delete_{pub,sub,service,client}_data` only erased the owning `shared_ptr` from the map, leaving `shutdown()` to run from whichever thread drops the last reference. If an entity is destroyed while one of its zenoh callbacks is in flight, the callback's transient `shared_ptr` (locked from the closure's `weak_ptr`) is the last reference, so the destructor runs the blocking undeclare on the zenoh callback thread itself — which waits for that same callback to finish. The thread deadlocks permanently and takes the entity mutex (and, on a deployed system, the whole session inbound path) with it. Full stacks and a field incident are in #993.

This PR:

* takes the entity out of the map under the lock, then shuts it down on the calling (application) thread outside the lock; the destructor's own `shutdown()` becomes a no-op via the existing `is_shutdown_` CAS regardless of which thread runs it (`rmw_node_data.cpp`);
* makes `ClientData::shutdown()` and `ServiceData::shutdown()` public, matching `PublisherData` / `SubscriptionData`;
* sets `initialized_ = true` at the end of `ServiceData::make()`. It was only ever initialized to `false`, so both undeclares in `ServiceData::shutdown()` were unreachable and the queryable was still undeclared by the member destructor — i.e. on the callback thread — even after the change above (found by @otamachan, see below);
* adds three deterministic regression tests in `test_rmw_zenoh_cpp`, one per entity kind that has a zenoh callback:
  * `test_client_destroy_during_reply`: blocks inside the new-response callback (invoked synchronously from `ClientData::add_new_reply` while the reply closure still holds its strong reference), destroys the client from the main thread, releases the callback, and verifies the callback thread can still serve a probe request;
  * `test_service_destroy_during_request`: same shape for a service, blocking inside the new-request callback invoked from `ServiceData::add_new_query` while the query closure holds its strong reference;
  * `test_subscription_destroy_during_sample`: parks one publishing thread inside the new-message callback (invoked from `add_new_message()` with `mutex_` held), starts the destroy so `shutdown()` queues on `mutex_`, then sends a second sample from another thread so a second callback is in flight when the undeclare runs. This guards the lock-release-before-undeclare ordering in `SubscriptionData::shutdown()` that #930 introduced on `rolling`; it is the AB-BA @otamachan hit on `jazzy`, where that ordering does not exist yet.

Rebased onto current `rolling`.

Verification (Docker `ros:rolling-ros-base`, Ubuntu 26.04 / x86_64, rolling binaries from `ros2-testing`, rebased onto `rolling` at 7fe3e65):

* `colcon test` for `rmw_zenoh_cpp` + `test_rmw_zenoh_cpp`: 236 tests, 0 failures, linters included. The three regression tests take ~1.1 s each and passed 3/3 reruns.
* Each test catches its bug when the corresponding fix is reverted:
  * `test_service_destroy_during_request` fails after its 10 s watchdog ("sender thread never returned … deadlocked") without the `initialized_ = true` line;
  * `test_subscription_destroy_during_sample` fails with "destroy returned: false, publisher B returned: false" when `SubscriptionData::shutdown()` is changed back to hold `mutex_` across the undeclare (the pre-#930 shape @otamachan hit on `jazzy`);
  * `test_client_destroy_during_reply` hangs with the original `delete_client_data` (caught by the test timeout), as in the previous revision of this PR.

### Is this user-facing behavior change?

No public API changes. It fixes a permanent deadlock/hang when a client, service or subscription is destroyed concurrently with an in-flight callback.

### Did you use Generative AI?

Yes. Claude (claude-fable-5 / claude-fable-5-1 and claude-opus-4-8) via Claude Code was used to assist with root cause analysis, reproducing the deadlock, and creating an initial prototype of the changes in this PR.

https://claude.ai/code/session_01317fxjjrM6WrQipxhN8qtm
