### PR TITLE
Fix lost wakeup during wait set attachment

### DIFF
--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -127,6 +127,7 @@ register_rmw_implementation(
 if(BUILD_TESTING)
   find_package(ament_cmake_copyright REQUIRED)
   find_package(ament_cmake_cpplint REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_lint_cmake REQUIRED)
   find_package(ament_cmake_uncrustify REQUIRED)
   find_package(ament_cmake_xmllint REQUIRED)
@@ -136,6 +137,13 @@ if(BUILD_TESTING)
   ament_lint_cmake()
   ament_uncrustify()
   ament_xmllint()
+
+  ament_add_gtest(test_rmw_wait test/test_rmw_wait.cpp)
+  target_include_directories(test_rmw_wait PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+  target_link_libraries(test_rmw_wait
+    ament_cmake_ros_core::ament_ros_defaults
+    rmw::rmw
+  )
 endif()
 
 install(

--- a/rmw_zenoh_cpp/package.xml
+++ b/rmw_zenoh_cpp/package.xml
@@ -31,6 +31,7 @@
   <depend>rmw_test_fixture</depend>
   <depend>tracetools</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/rmw_zenoh_cpp/src/detail/rmw_wait.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_wait.hpp
@@ -1,0 +1,34 @@
+// Copyright 2026 ktyang512
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DETAIL__RMW_WAIT_HPP_
+#define DETAIL__RMW_WAIT_HPP_
+
+#include "rmw/rmw.h"
+
+#include "rmw_wait_set_data.hpp"
+
+namespace rmw_zenoh_cpp::detail
+{
+
+inline bool condition_attachment_scan_complete(const rmw_wait_set_data_t *)
+{
+  // An entity may have set triggered while the attachment scan was in progress. Do not overwrite
+  // that notification here; rmw_wait() resets the flag under the mutex before starting the scan.
+  return false;
+}
+
+}  // namespace rmw_zenoh_cpp::detail
+
+#endif  // DETAIL__RMW_WAIT_HPP_

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -36,6 +36,7 @@
 #include "detail/message_type_support.hpp"
 #include "detail/qos.hpp"
 #include "detail/rmw_context_impl_s.hpp"
+#include "detail/rmw_wait.hpp"
 #include "detail/serialization_format.hpp"
 #include "detail/type_support_common.hpp"
 #include "detail/zenoh_utils.hpp"
@@ -2185,12 +2186,7 @@ check_and_attach_condition(
     }
   }
 
-  // No conditions are available. Set the triggered flag of the wait_set to false.
-  // Note that wait_set_data->condition_mutex has been locked before calling
-  // check_and_attach_condition. So it's safe to modify the wait_set_data triggered flag.
-  wait_set_data->triggered = false;
-
-  return false;
+  return rmw_zenoh_cpp::detail::condition_attachment_scan_complete(wait_set_data);
 }
 }  // namespace
 

--- a/rmw_zenoh_cpp/test/test_rmw_wait.cpp
+++ b/rmw_zenoh_cpp/test/test_rmw_wait.cpp
@@ -1,0 +1,31 @@
+// Copyright 2026 ktyang512
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "detail/rmw_wait.hpp"
+#include "detail/rmw_wait_set_data.hpp"
+
+TEST(TestRmwWait, preserves_trigger_set_during_condition_attachment)
+{
+  rmw_zenoh_cpp::rmw_wait_set_data_t wait_set_data{};
+
+  // Model the relevant interleaving without scheduler-dependent sleeps: an attached entity sets
+  // the flag while rmw_wait() is still scanning the remaining entities.
+  wait_set_data.triggered = true;
+
+  // Finishing the scan must not erase the notification before rmw_wait() evaluates its predicate.
+  EXPECT_FALSE(rmw_zenoh_cpp::detail::condition_attachment_scan_complete(&wait_set_data));
+  EXPECT_TRUE(wait_set_data.triggered);
+}


### PR DESCRIPTION
## Description

Prevent `check_and_attach_condition()` from clearing
`wait_set_data->triggered` after its unlocked entity scan.

`rmw_wait()` already resets this flag under `condition_mutex` before the scan.
An entity can then set it while the remaining entities are being attached. The
second, unlocked reset erased that notification and could make a no-timer wait
sleep indefinitely.

This change makes attachment-scan completion read-only and adds a deterministic
regression test for the relevant ordering, without scheduler-dependent sleeps.

Fixes #1032

### Is this user-facing behavior change?

Yes. Executors without a timer no longer risk stalling indefinitely when an
entity becomes ready during wait-set attachment.

### Did you use Generative AI?

Yes. OpenAI Codex (GPT-5) assisted with repository analysis, the internal test
seam, regression test, implementation, validation, and PR text. The contributor
reviewed the rationale and selected the test design before submission.

### Additional Information

The regression failed before the fix because `triggered` became false. After
the fix, it passed 100 consecutive runs.

Local Rolling binary-path validation:

- built `zenoh_cpp_vendor`, `rmw_zenoh_cpp`, `zenoh_security_tools`, and
  `test_rmw_zenoh_cpp`;
- `colcon test-result`: 246 tests, 0 errors, 0 failures, 4 skipped;
- the skips are cppcheck records because the image's cppcheck 2.19 is
  intentionally not run by `ament_cppcheck` due to known performance issues;
- copyright, cpplint, lint_cmake, uncrustify, xmllint, the regression test, and
  isolated Zenoh session tests passed.

The Rolling-from-source / Ubuntu Resolute CI leg and release-branch backports
were not run locally.
