### PR TITLE
Do not update wait_set_data triggered flag outside of mutex lock

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2185,11 +2185,6 @@ check_and_attach_condition(
     }
   }
 
-  // No conditions are available. Set the triggered flag of the wait_set to false.
-  // Note that wait_set_data->condition_mutex has been locked before calling
-  // check_and_attach_condition. So it's safe to modify the wait_set_data triggered flag.
-  wait_set_data->triggered = false;
-
   return false;
 }
 }  // namespace
@@ -2242,7 +2237,7 @@ rmw_wait(
 
   {
     // We explicitly do not lock the condition_mutex here
-    // This is fine, as the attachment returns atomically is a signal was ready
+    // This is fine, as the attachment returns atomically if a signal was ready
     // If anything triggers after that point, wait_set_data->triggered will be set
     // to true under mutex.
     // Note taking the mutex here leads to a deadlock.

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2111,6 +2111,9 @@ check_and_attach_condition(
   const rmw_events_t * const events,
   rmw_zenoh_cpp::rmw_wait_set_data_t * wait_set_data)
 {
+  // This function runs without wait_set_data->condition_mutex. Taking it here
+  // deadlocks against the producers, so this function must never write
+  // wait_set_data->triggered.
   if (guard_conditions) {
     for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
       rmw_zenoh_cpp::GuardCondition * gc =


### PR DESCRIPTION
## Description

https://github.com/ros2/rmw_zenoh/pull/1005 did the right thing by resetting the `wait_set_data->triggered` flag to `false` under global lock as [seen here](https://github.com/ros2/rmw_zenoh/blob/e3159856e3816e726f2c5f1f9b4858ad6b7ee63e/rmw_zenoh_cpp/src/rmw_zenoh.cpp#L2237-L2241) but it kept the reset in [check_and_attach_condition()](https://github.com/ros2/rmw_zenoh/blob/e3159856e3816e726f2c5f1f9b4858ad6b7ee63e/rmw_zenoh_cpp/src/rmw_zenoh.cpp#L2188-L2191) that is no longer called under the same lock. This leads to the executor waiting indefinitely if one of the entities received a message after the initial check in `check_and_attach_condition()` given the reset happens outside of a lock.


<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

https://github.com/ros2/rmw_zenoh/issues/1032

### Is this user-facing behavior change?
Yes. Fixes indefinite executor wait.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No 

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
