### PR TITLE
Add rmw_zenoh_cpp to zenoh_cpp_vendor runtime dep

### DIFF
--- a/rmw_zenoh_cpp/package.xml
+++ b/rmw_zenoh_cpp/package.xml
@@ -17,8 +17,6 @@
   <buildtool_export_depend>ament_cmake_ros_core</buildtool_export_depend>
 
   <build_depend>nlohmann-json-dev</build_depend>
-  <build_depend>zenoh_cpp_vendor</build_depend>
-  <build_export_depend>zenoh_cpp_vendor</build_export_depend>
 
   <depend>ament_index_cpp</depend>
   <depend>fastcdr</depend>
@@ -30,6 +28,7 @@
   <depend>rmw</depend>
   <depend>rmw_test_fixture</depend>
   <depend>tracetools</depend>
+  <depend>zenoh_cpp_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Description

This dependency is currently only declared for build time, however using `rmw_zenoh_cpp` requires `libzenohc.so` to be installed, provided by `zenoh_cpp_vendor`.

This hasn't been much of a problem because in most places, we treat `build_export_depend` the same as `exec_depend`. It does break today when installing packages on RHEL 10, where we have separate `-runtime` and `-devel` subpackages.

### Is this user-facing behavior change?

This is a bugfix that will only affect RHEL 10 and Fedora  users.

### Did you use Generative AI?

No

### Additional Information

Should be backported (at least) to Lyrical.