### PR TITLE
Remove unnecessary topic info locks

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -735,7 +735,6 @@ std::size_t PublisherData::gid_hash() const
 ///=============================================================================
 liveliness::TopicInfo PublisherData::topic_info() const
 {
-  std::lock_guard<std::mutex> lock(mutex_);
   return entity_->topic_info().value();
 }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -511,7 +511,6 @@ std::size_t SubscriptionData::gid_hash() const
 ///=============================================================================
 liveliness::TopicInfo SubscriptionData::topic_info() const
 {
-  std::lock_guard<std::mutex> lock(mutex_);
   return entity_->topic_info().value();
 }
 


### PR DESCRIPTION
## Description

Remove unnecessary mutex acquisition from `PublisherData::topic_info()` and `SubscriptionData::topic_info()`.

Each endpoint's entity_ is assigned during construction and is never replaced or reset. The TopicInfo stored by Entity is also initialized during construction and is never mutated. 

Consequently, topic_info() only reads immutable, lifetime-stable state. Locking the endpoint mutex does not protect any state involved in this operation and adds unnecessary synchronization.

### Is this user-facing behavior change?

No I don't think so

### Did you use Generative AI?

Yes, I asked Codex 5.6 Sol to generate the PR description. The code change did not involve AI

### Additional Information

I assumed the locks are not needed here, but if there is a reason they are still necessary, I would be interested to understand why